### PR TITLE
Fixed boss icons z-indexes

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,7 +310,8 @@
                     category: info.category,
                     icon: CreateIcon(info.icoPath),
                     toolTipContent: info.tooltip,
-                    icoPath: info.icoPath
+                    icoPath: info.icoPath,
+                    zIndexOffset: 1000
                 })
                 marker.bindPopup(info.popup);
                 marker.bindTooltip(info.tooltip, { direction: 'left' });


### PR DESCRIPTION
Hi, and good day.

Thanks for creating this interactive map. I just finished S&S and found your map, great job! 

However, I noticed that when you zoom out, or by default (based on how wide your monitor) the boss (skull) icon is sometimes not-hoverable because it's covered by text, So even when you hover over it, nothing happens and you cannot interact with it.

To address this, I did some research and found out that setting a high-value number to be `zIndexOffset` when creating `Marker` can solve this.

Please see the below images as examples of before and after my changes:

## Before & After:

### Example 1:

#### 1) Before:
![1-before](https://github.com/Kaszub09/SSMap/assets/76709894/a3710d16-53f3-4535-b9c1-f13694e8bc5d)

#### 2) After:
![1-after](https://github.com/Kaszub09/SSMap/assets/76709894/b692266a-edbd-45c7-b8a2-f0a256554bed)



### Example 2:

#### 1) Before:
![2-before](https://github.com/Kaszub09/SSMap/assets/76709894/bc319364-7903-4366-aa4b-5845ca02422a)

#### 2) After:
![2-after](https://github.com/Kaszub09/SSMap/assets/76709894/e017cd44-c240-4d33-b367-fa8b0c24223b)



### Example 3:

#### 1) Before:
![3-before](https://github.com/Kaszub09/SSMap/assets/76709894/9e9bc338-8fb3-4486-a4c9-67cc061bde3f)

#### 2) After:
![3-after](https://github.com/Kaszub09/SSMap/assets/76709894/b3a1cb9b-2c3b-4e2c-9d58-84c249aa8f1e)


### Example 4 (Full map):

#### 1) Before:
![4-before](https://github.com/Kaszub09/SSMap/assets/76709894/c54496f3-c31e-4b86-b7b4-bfdda9dbce73)

#### 2) After:
![4-after](https://github.com/Kaszub09/SSMap/assets/76709894/f524385c-dbcc-4418-a976-b7edfe4cdbb3)


---


Please let me know if I need to update anything else, I would be happy to edit this PR further, thanks.